### PR TITLE
Adjusted the hole size for the larger toroid pads to 0.9mm

### DIFF
--- a/db9-horizontal-autoband.brd
+++ b/db9-horizontal-autoband.brd
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.500000001" unitdist="mm" unit="mm" style="lines" multiple="1" display="no" altdistance="0.1" altunitdist="mm" altunit="mm"/>
+<grid distance="0.5" unitdist="mm" unit="mm" style="lines" multiple="1" display="no" altdistance="0.1" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="yes"/>
@@ -1189,8 +1189,8 @@ Metric Code Size 2012</description>
 <package name="T30-2-28AWG-15T">
 <text x="-1.36" y="-3.63" size="1.27" layer="25">&gt;NAME</text>
 <text x="-1.36" y="-5.4" size="1.27" layer="27">&gt;VALUE</text>
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="2.32"/>
-<pad name="P$2" x="5.08" y="0" drill="0.8" diameter="2.32"/>
+<pad name="P$1" x="0" y="0" drill="0.9" diameter="2.32"/>
+<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="2.32"/>
 </package>
 </packages>
 </library>

--- a/db9-horizontal-autoband.sch
+++ b/db9-horizontal-autoband.sch
@@ -100,8 +100,8 @@
 <package name="T30-2-28AWG-15T">
 <text x="-1.36" y="-3.63" size="1.27" layer="25">&gt;NAME</text>
 <text x="-1.36" y="-5.4" size="1.27" layer="27">&gt;VALUE</text>
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="2.32"/>
-<pad name="P$2" x="5.08" y="0" drill="0.8" diameter="2.32"/>
+<pad name="P$1" x="0" y="0" drill="0.9" diameter="2.32"/>
+<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="2.32"/>
 </package>
 </packages>
 <symbols>

--- a/headers-160m.brd
+++ b/headers-160m.brd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="8.1.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.3175" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="1.27" altunitdist="mm" altunit="mm"/>
+<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.1" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="no" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -16,8 +16,8 @@
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
@@ -1170,8 +1170,8 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <package name="T30-2-28AWG-15T">
 <text x="-1.36" y="-3.63" size="1.27" layer="25">&gt;NAME</text>
 <text x="-1.36" y="-5.4" size="1.27" layer="27">&gt;VALUE</text>
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="2.32"/>
-<pad name="P$2" x="5.08" y="0" drill="0.8" diameter="2.32"/>
+<pad name="P$1" x="0" y="0" drill="0.9" diameter="2.32"/>
+<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="2.32"/>
 </package>
 </packages>
 </library>

--- a/headers-160m.sch
+++ b/headers-160m.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="8.1.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -194,8 +194,8 @@
 <package name="T30-2-28AWG-15T">
 <text x="-1.36" y="-3.63" size="1.27" layer="25">&gt;NAME</text>
 <text x="-1.36" y="-5.4" size="1.27" layer="27">&gt;VALUE</text>
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="2.32"/>
-<pad name="P$2" x="5.08" y="0" drill="0.8" diameter="2.32"/>
+<pad name="P$1" x="0" y="0" drill="0.9" diameter="2.32"/>
+<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="2.32"/>
 </package>
 </packages>
 <symbols>

--- a/toroids.lbr
+++ b/toroids.lbr
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="8.1.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -66,8 +66,8 @@
 <package name="T30-2-28AWG-15T">
 <text x="-1.36" y="-3.63" size="1.27" layer="25">&gt;NAME</text>
 <text x="-1.36" y="-5.4" size="1.27" layer="27">&gt;VALUE</text>
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="2.32"/>
-<pad name="P$2" x="5.08" y="0" drill="0.8" diameter="2.32"/>
+<pad name="P$1" x="0" y="0" drill="0.9" diameter="2.32"/>
+<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="2.32"/>
 </package>
 </packages>
 <symbols>


### PR DESCRIPTION
Adjusted the hole size to allow use of 0.8mm enamelled copper wire for
the larger toroids. Larger wire provides better rigidity and marginally
lower loss. Updated the db9-horizontal-autoband and headers-160m files with the modified toroid library entry for the large toroid.